### PR TITLE
Integrate K3Z TIPSY-vs-VDYP plots into the user docs

### DIFF
--- a/docs/base-case-analysis.rst
+++ b/docs/base-case-analysis.rst
@@ -16,6 +16,8 @@ Primary evidence sources:
 - ``models/k3z_patchworks_model/tracks/*.csv``
 - ``vdyp_io/logs/patchworks_matrixbuilder_manifest-*.json``
 - run-id-specific matrix logs and manifests under ``vdyp_io/logs/``
+- :doc:`yield-curve-comparisons` for the student-facing treated TIPSY-vs-VDYP
+  figure set
 - Appendix figure catalog in :ref:`k3z-figure-appendix`
 
 Base Case Output and Interpretation
@@ -77,6 +79,9 @@ core modeling mechanics.
 
 Figure Appendix Linkage
 -----------------------
+
+Use :doc:`yield-curve-comparisons` when the main question is how the treated
+TIPSY curves compare visually against the corresponding VDYP reference curves.
 
 Use :ref:`k3z-figure-appendix` as the canonical catalog for K3Z diagnostic and
 teaching figures. Reference specific plot files by name in interpretation notes

--- a/docs/data-package-crosswalk.rst
+++ b/docs/data-package-crosswalk.rst
@@ -31,8 +31,9 @@ Section Crosswalk
    * - Discussion
      - ``base-case-analysis.rst``
    * - Figures, charts, and map exhibits
-     - ``figure-appendix.rst`` plus cross-references from
-       ``land-base-and-netdown.rst`` and ``base-case-analysis.rst``
+     - ``yield-curve-comparisons.rst`` and ``figure-appendix.rst`` plus
+       cross-references from ``land-base-and-netdown.rst`` and
+       ``base-case-analysis.rst``
    * - References
      - ``base-case-analysis.rst`` and ``assumptions-registry.rst``
 

--- a/docs/figure-appendix.rst
+++ b/docs/figure-appendix.rst
@@ -246,8 +246,14 @@ VDYP Fit Diagnostics
 
    VDYP fit diagnostic for stratum/SI bin ``08-CWHvm_CW+PLC-M`` (source: ``plots/vdyp_fitdiag_tsak3z-08-CWHvm_CW+PLC-M.png``).
 
+.. _k3z-treated-yield-curve-overlays:
+
 Treated (TIPSY vs VDYP) Curve Overlays
 --------------------------------------
+
+For the student-facing explanation and direct guide entry point for these
+figures, use :doc:`yield-curve-comparisons`. This appendix remains the full
+catalog and filename-traceability surface.
 
 .. note::
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -54,6 +54,9 @@ The intended launch pairings are:
 
 For the full launch matrix, use :doc:`variants-and-subvariants`.
 
+For the student-facing treated yield-curve comparison figures, use
+:doc:`yield-curve-comparisons`.
+
 Quick Surface Picker
 --------------------
 
@@ -204,6 +207,9 @@ Baseline K3Z Policy Notes
 -------------------------
 
 - Managed curves now come from real BatchTIPSY output.
+- The student-facing treated TIPSY-vs-VDYP comparison figures live in
+  :doc:`yield-curve-comparisons`, with the full plot catalog retained in
+  :ref:`k3z-figure-appendix`.
 - `CWHvm_CW+YC` and `CWHvm_CW+PLC` are intentionally excluded from the
   treated/TIPSY path and retained out of THLB with `RETENTION = 1.0`.
 - Remaining treated AUs use the simplified teaching planting rules documented

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ This documentation site is the standalone operator guide for the
    land-base-and-netdown
    assumptions-registry
    base-case-analysis
+   yield-curve-comparisons
    figure-appendix
    metadata-and-lineage
    operator-runbook

--- a/docs/model-anatomy.rst
+++ b/docs/model-anatomy.rst
@@ -168,4 +168,5 @@ Deep references
 
 - full launch matrix: :doc:`variants-and-subvariants`
 - treatment/state-machine details: :doc:`silviculture-logic`
+- student-facing treated curve gallery: :doc:`yield-curve-comparisons`
 - old-growth attribute logic: :doc:`old-growth-attributes`

--- a/docs/yield-curve-comparisons.rst
+++ b/docs/yield-curve-comparisons.rst
@@ -1,0 +1,132 @@
+.. _k3z-yield-curve-comparisons:
+
+Yield Curve Comparisons
+=======================
+
+Purpose
+-------
+
+This page surfaces the current K3Z treated-yield comparison figures in a place
+students can reach directly from the main guide flow.
+
+These figures compare the treated TIPSY-driven managed curve against the
+corresponding VDYP reference curve for each currently active treated AU in the
+K3Z teaching baseline.
+
+Use this page when you want to answer questions such as:
+
+- which treated AUs currently have comparison plots;
+- how the managed TIPSY curve differs in shape or timing from the VDYP
+  reference curve;
+- whether the current treated-curve story looks plausible enough for teaching
+  and interpretation.
+
+How To Read These Figures
+-------------------------
+
+- Treat each figure as a one-AU comparison between the managed TIPSY pathway
+  and the corresponding VDYP reference curve.
+- Focus first on broad shape: early growth, peak timing, and whether the two
+  curves stay close or diverge strongly at older ages.
+- Use the figures as interpretation aids, not as a substitute for the
+  underlying exported curves, tracks, or account surfaces.
+- For the full catalog of K3Z figures and source filenames, use
+  :ref:`k3z-figure-appendix`.
+
+Current Coverage
+----------------
+
+The current treated comparison set includes the active treated AUs that still
+participate in the TIPSY pathway.
+
+.. note::
+
+   The low-yield ``CWHvm_CW+YC`` and ``CWHvm_CW+PLC`` strata are intentionally
+   excluded from the treated/TIPSY pathway in the current K3Z teaching
+   baseline. Their area is retained out of THLB via ``RETENTION = 1.0``, so
+   there are no current treated TIPSY-vs-VDYP overlay figures for AUs
+   ``22006`` and ``22008``.
+
+Current TIPSY-vs-VDYP Gallery
+-----------------------------
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-21000.png
+   :alt: tipsy_vdyp_tsak3z-21000.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``21000``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-21001.png
+   :alt: tipsy_vdyp_tsak3z-21001.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``21001``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-21003.png
+   :alt: tipsy_vdyp_tsak3z-21003.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``21003``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22001.png
+   :alt: tipsy_vdyp_tsak3z-22001.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22001``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22002.png
+   :alt: tipsy_vdyp_tsak3z-22002.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22002``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22003.png
+   :alt: tipsy_vdyp_tsak3z-22003.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22003``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22004.png
+   :alt: tipsy_vdyp_tsak3z-22004.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22004``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22005.png
+   :alt: tipsy_vdyp_tsak3z-22005.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22005``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-22007.png
+   :alt: tipsy_vdyp_tsak3z-22007.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``22007``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-23000.png
+   :alt: tipsy_vdyp_tsak3z-23000.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``23000``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-23001.png
+   :alt: tipsy_vdyp_tsak3z-23001.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``23001``.
+
+.. figure:: ../plots/tipsy_vdyp_tsak3z-23003.png
+   :alt: tipsy_vdyp_tsak3z-23003.png
+   :width: 90%
+
+   TIPSY-vs-VDYP treated yield-curve comparison for AU ``23003``.
+
+Where These Figures Come From
+-----------------------------
+
+- Plot files live under ``plots/`` in this instance checkout.
+- The current rendered source filenames are retained in
+  :ref:`k3z-figure-appendix`.
+- Rebuild and QA guidance for regenerating or checking these figures lives in
+  :doc:`rebuild-and-qa` and :doc:`operator-runbook`.


### PR DESCRIPTION
## Summary
- add a dedicated student-facing K3Z docs page for the treated TIPSY-vs-VDYP yield-curve comparison figures
- wire that page into the normal K3Z guide flow so students can find the figures without relying on the appendix alone
- keep the figure appendix as the filename-traceability catalog while using the new page as the main interpretation entry point

## Docs updated
- docs/yield-curve-comparisons.rst (new)
- docs/index.rst
- docs/getting-started.rst
- docs/base-case-analysis.rst
- docs/model-anatomy.rst
- docs/data-package-crosswalk.rst
- docs/figure-appendix.rst

## Validation
- sphinx-build -b html docs docs\\_build\\html -W

## Related
- Implements GitHub issue 13, which is already closed with an explicit closeout note