### PR TITLE
Use human-readable AU labels in K3Z Patchworks docs

### DIFF
--- a/docs/base-case-analysis.rst
+++ b/docs/base-case-analysis.rst
@@ -28,7 +28,7 @@ Base Case Output and Interpretation
 - Validate unexpected zeros/nulls by tracing:
   curve definitions -> attributes/products -> accounts -> targets.
 - Interpret seral inventory state primarily from
-  ``feature.Seral.<au_id>.<stage>`` accounts; keep
+  ``feature.Seral.<au_label>.<stage>`` accounts; keep
   ``feature.Seral.<stage>`` as the instance-wide compatibility/summary surface.
 
 Species Code Note (PL vs PLC)

--- a/docs/model-anatomy.rst
+++ b/docs/model-anatomy.rst
@@ -47,12 +47,12 @@ Core Feature and Product Surfaces
 Seral account surfaces:
 
 - Global compatibility surface: ``feature.Seral.<stage>``
-- AU-specific inventory-state surface: ``feature.Seral.<au_id>.<stage>``
-- Treatment consequence surface: ``product.Seral.area.<stage>.<au_id>.CC``
+- AU-specific inventory-state surface: ``feature.Seral.<au_label>.<stage>``
+- Treatment consequence surface: ``product.Seral.area.<stage>.<au_label>.CC``
 
 Old-growth surfaces:
 
-- ``feature.Area.og1.<au_id>``
+- ``feature.Area.og1.<au_label>``
 - ``feature.Area.og2.<au_id>``
 - ``feature.Area.og1.total``
 - ``feature.Area.og2.total``

--- a/docs/old-growth-attributes.rst
+++ b/docs/old-growth-attributes.rst
@@ -12,7 +12,7 @@ Attribute Labels
 
 Per-AU labels:
 
-- ``feature.Area.og1.<au_id>``
+- ``feature.Area.og1.<au_label>``
 - ``feature.Area.og2.<au_id>``
 
 Instance-wide summary labels:

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -178,7 +178,7 @@ Old-Growth Review Workflow
 After a normal baseline rebuild on ``main``, confirm the old-growth surfaces are
 present in compiled accounts:
 
-- ``feature.Area.og1.<au_id>``
+- ``feature.Area.og1.<au_label>``
 - ``feature.Area.og2.<au_id>``
 - ``feature.Area.og1.total``
 - ``feature.Area.og2.total``


### PR DESCRIPTION
## Summary
- update K3Z user-facing docs to show human-readable AU labels in Patchworks surfaces
- align the operator and analysis pages with the new exported account-name format

## Validation
- sphinx-build -b html docs docs\\_build\\html -W