### PR TITLE
Automate Matrix Builder window cleanup on Windows

### DIFF
--- a/config/patchworks.runtime.ctfert_l15h5.windows.yaml
+++ b/config/patchworks.runtime.ctfert_l15h5.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_ctfert_l15h5_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_ctfert_l15h5
   forestmodel_xml_path: ../output/patchworks_k3z_ctfert_l15h5_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.ctfert_l20h0.windows.yaml
+++ b/config/patchworks.runtime.ctfert_l20h0.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_ctfert_l20h0_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_ctfert_l20h0
   forestmodel_xml_path: ../output/patchworks_k3z_ctfert_l20h0_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.intensive_heavy.windows.yaml
+++ b/config/patchworks.runtime.intensive_heavy.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_intensive_heavy_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_intensive_heavy
   forestmodel_xml_path: ../output/patchworks_k3z_intensive_heavy_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.intensive_light.windows.yaml
+++ b/config/patchworks.runtime.intensive_light.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_intensive_light_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_intensive_light
   forestmodel_xml_path: ../output/patchworks_k3z_intensive_light_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.intensive_moderate.windows.yaml
+++ b/config/patchworks.runtime.intensive_moderate.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_intensive_moderate_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_intensive_moderate
   forestmodel_xml_path: ../output/patchworks_k3z_intensive_moderate_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.overlay.basecase_riparian.windows.yaml
+++ b/config/patchworks.runtime.overlay.basecase_riparian.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_overlay_basecase_riparian_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_overlay_basecase_riparian
   forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.overlay.basecase_sum.windows.yaml
+++ b/config/patchworks.runtime.overlay.basecase_sum.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_overlay_basecase_sum_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_overlay_basecase_sum
   forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.overlay.scenario1_sum.windows.yaml
+++ b/config/patchworks.runtime.overlay.scenario1_sum.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_overlay_scenario1_sum_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_overlay_scenario1_sum
   forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.overlay.scenario2_sum.windows.yaml
+++ b/config/patchworks.runtime.overlay.scenario2_sum.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_overlay_scenario2_sum_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_overlay_scenario2_sum
   forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.pct_heavy.windows.yaml
+++ b/config/patchworks.runtime.pct_heavy.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_pct_heavy_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_pct_heavy
   forestmodel_xml_path: ../output/patchworks_k3z_pct_heavy_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.pct_light.windows.yaml
+++ b/config/patchworks.runtime.pct_light.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_pct_light_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_pct_light
   forestmodel_xml_path: ../output/patchworks_k3z_pct_light_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.pct_moderate.windows.yaml
+++ b/config/patchworks.runtime.pct_moderate.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_pct_moderate_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks_pct_moderate
   forestmodel_xml_path: ../output/patchworks_k3z_pct_moderate_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/config/patchworks.runtime.windows.yaml
+++ b/config/patchworks.runtime.windows.yaml
@@ -10,6 +10,9 @@ matrix_builder:
   fragments_path: ../output/patchworks_k3z_validated/fragments/fragments.dbf
   output_dir: ../models/k3z_patchworks_model/tracks
   forestmodel_xml_path: ../output/patchworks_k3z_validated/forestmodel.xml
+  auto_close_window_on_success: true
+  auto_close_settle_seconds: 2.0
+  auto_close_timeout_seconds: 10.0
   harvested_volume_utilization_by_treatment:
     CC: 0.85
     CT: 0.75

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -53,6 +53,12 @@ Diagnostics Workflow
    femic tsa post-tipsy --run-config config/run_profile.k3z.yaml --tsa k3z --run-id k3z_reprocheck
    femic patchworks matrix-build --config config/patchworks.runtime.windows.yaml --run-id k3z_reprocheck
 
+On the shipped Windows runtime configs, FEMIC now supervises the noninteractive
+Matrix Builder launch and automatically closes the spawned Matrix Builder GUI
+window after fresh output activity has stabilized. This is intended to remove
+the routine manual "close the Matrix Builder window so the workflow can
+continue" step from local rebuilds.
+
 Review:
 
 - ``vdyp_io/logs/patchworks_matrixbuilder_manifest-<run_id>.json``


### PR DESCRIPTION
Automate native-Windows Matrix Builder cleanup so the local coding-agent workflow no longer depends on a human to dismiss the Matrix Builder GUI or its lingering Patchworks launcher shell.\n\nValidation:\n- ruff format src tests\n- ruff check src tests\n- mypy src\n- pytest\n- pre-commit run --all-files\n- sphinx-build -b html docs _build/html -W\n- standalone K3Z Sphinx build\n- real Windows smoke: python -m femic patchworks matrix-build --config external/femic-k3z-instance/config/patchworks.runtime.windows.yaml --run-id k3z_autoclose_shell_smoke_20260327\n\nIssue: #44