### PR TITLE
P49 add useful base-K3Z headless Patchworks helper defaults

### DIFF
--- a/models/k3z_patchworks_model/analysis/base_variant_common.bsh
+++ b/models/k3z_patchworks_model/analysis/base_variant_common.bsh
@@ -24,6 +24,7 @@ boolean usePatches = false;
 sourceRelative("../scripts/targets/flowTargets.bsh");
 sourceRelative("../scripts/targets/qmdRatioAccounts.bsh");
 sourceRelative("../scripts/targets/seralStages.bsh");
+sourceRelative("headless_runtime_common.bsh");
 
 /*
  * Locate the input matrix data files
@@ -121,81 +122,85 @@ int PatchWorks_Init() {
    /*
     * Load the default user interface
     */
-   classic_GUI(control);
+   femicConfigureHeadlessFromArgs();
 
-   /*
-    * Set up the initial harvest targets
-    * Uncomment and edit these lines if required
-    */
-   // control.loadTargetSummary("initialTargetSummary.csv");
-   // control.loadTargetStatus("initialTargetStatus.csv");
+   if (!femicHeadlessMode) {
+      classic_GUI(control);
 
-   /*
-    * Establish the initial timing constraints
-    * Uncomment and edit these lines if required
-    */
-   // control.getAccessTable().setKey("COMPART");
-   // control.getAccessTable().load("access.csv");
-   // control.getAccessTable().apply();
+      /*
+       * Set up the initial harvest targets
+       * Uncomment and edit these lines if required
+       */
+      // control.loadTargetSummary("initialTargetSummary.csv");
+      // control.loadTargetStatus("initialTargetStatus.csv");
 
-   /*
-    * Add Map layer definitions here.  The first layer
-    * added will appear on the bottom of the legend.
-    */
+      /*
+       * Establish the initial timing constraints
+       * Uncomment and edit these lines if required
+       */
+      // control.getAccessTable().setKey("COMPART");
+      // control.getAccessTable().load("access.csv");
+      // control.getAccessTable().apply();
 
-   /*
-    * This is a single coloured theme that show the blocks
-    */
-    DefaultTheme def = new DefaultTheme(blockData, new PolygonSymbol(new Color(204, 204, 255)));
-    Layer defLayer = new GeoRelLayer(blockData, def);
-    layers.add(defLayer);
+      /*
+       * Add Map layer definitions here.  The first layer
+       * added will appear on the bottom of the legend.
+       */
 
-   /*
-    * This map layer shows the harvest treatments in the current period
-    */
-    UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
-    currTreatTheme.setFieldname("CURRENTTREATMENT");
-    currTreatTheme.addElement(new ThemeElement("CC",
-        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)),
-        "CC");
-    currTreatTheme.setCaption("Current Treatments");
-    currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
-    blockData.addTheme(currTreatTheme);
-    GeoRelLayer currTreatLayer = new GeoRelLayer(blockData, currTreatTheme);
-    currTreatLayer.setVisible(false);
-    layers.add(currTreatLayer);
+      /*
+       * This is a single coloured theme that show the blocks
+       */
+      DefaultTheme def = new DefaultTheme(blockData, new PolygonSymbol(new Color(204, 204, 255)));
+      Layer defLayer = new GeoRelLayer(blockData, def);
+      layers.add(defLayer);
 
-   /*
-    * This map layer shows the all harvest treatments applied up until the current period
-    */
-    UniqueValueTheme latestTreatTheme = new UniqueValueTheme(blockData);
-    latestTreatTheme.setFieldname("LASTTREATMENT");
-    latestTreatTheme.addElement(new ThemeElement("CC",
-        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)),
-        "CC");
-    latestTreatTheme.setCaption("Latest Treatments");
-    latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
-    blockData.addTheme(latestTreatTheme);
-    GeoRelLayer latestTreatLayer = new GeoRelLayer(blockData, latestTreatTheme);
-    latestTreatLayer.setVisible(false);
-    layers.add(latestTreatLayer);
-   /*
-    * Create a dithered theme based on seral stage.
-    */
-    AlphaComposite alpha = AlphaComposite.SrcOver;
-    global.seral2 = new DitherTheme(blockData, "feature.Seral.");
-    seral2.setCaption("Dithered Seral Stage");
-    seral2.setAlpha(alpha);
-    seral2.setIsScaled(false);
-    seral2.addElement("Regen", new Color (250, 230, 0), "feature.Seral.regenerating");
-    seral2.addElement("Young", new Color (200, 250, 200), "feature.Seral.young");
-    seral2.addElement("Immature", new Color (160, 220, 160), "feature.Seral.immature");
-    seral2.addElement("Mature", new Color (100, 190, 100), "feature.Seral.mature");
-    seral2.addElement("Old", new Color (128, 64, 64), "feature.Seral.overmature");
-    blockData.addTheme(seral2, "Dithered Seral Stage");
-    Layer seral2Layer = new GeoRelLayer(blockData, seral2);
-    seral2Layer.setTitle("Seral Stages");
-    layers.add(seral2Layer);
+      /*
+       * This map layer shows the harvest treatments in the current period
+       */
+      UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
+      currTreatTheme.setFieldname("CURRENTTREATMENT");
+      currTreatTheme.addElement(new ThemeElement("CC",
+          PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)),
+          "CC");
+      currTreatTheme.setCaption("Current Treatments");
+      currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+      blockData.addTheme(currTreatTheme);
+      GeoRelLayer currTreatLayer = new GeoRelLayer(blockData, currTreatTheme);
+      currTreatLayer.setVisible(false);
+      layers.add(currTreatLayer);
+
+      /*
+       * This map layer shows the all harvest treatments applied up until the current period
+       */
+      UniqueValueTheme latestTreatTheme = new UniqueValueTheme(blockData);
+      latestTreatTheme.setFieldname("LASTTREATMENT");
+      latestTreatTheme.addElement(new ThemeElement("CC",
+          PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)),
+          "CC");
+      latestTreatTheme.setCaption("Latest Treatments");
+      latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+      blockData.addTheme(latestTreatTheme);
+      GeoRelLayer latestTreatLayer = new GeoRelLayer(blockData, latestTreatTheme);
+      latestTreatLayer.setVisible(false);
+      layers.add(latestTreatLayer);
+      /*
+       * Create a dithered theme based on seral stage.
+       */
+      AlphaComposite alpha = AlphaComposite.SrcOver;
+      global.seral2 = new DitherTheme(blockData, "feature.Seral.");
+      seral2.setCaption("Dithered Seral Stage");
+      seral2.setAlpha(alpha);
+      seral2.setIsScaled(false);
+      seral2.addElement("Regen", new Color (250, 230, 0), "feature.Seral.regenerating");
+      seral2.addElement("Young", new Color (200, 250, 200), "feature.Seral.young");
+      seral2.addElement("Immature", new Color (160, 220, 160), "feature.Seral.immature");
+      seral2.addElement("Mature", new Color (100, 190, 100), "feature.Seral.mature");
+      seral2.addElement("Old", new Color (128, 64, 64), "feature.Seral.overmature");
+      blockData.addTheme(seral2, "Dithered Seral Stage");
+      Layer seral2Layer = new GeoRelLayer(blockData, seral2);
+      seral2Layer.setTitle("Seral Stages");
+      layers.add(seral2Layer);
+   }
 
    /*
     * Put patch maps here.
@@ -238,6 +243,9 @@ int PatchWorks_Init() {
          null,
          false
     ));
+
+   if (femicHeadlessMode)
+      femicQueueHeadlessStage();
 
    /*
     * Put route reports here.

--- a/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
+++ b/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
@@ -130,17 +130,21 @@ void femicConfigureHeadlessScenario() {
       throw new IllegalStateException("Unsupported FEMIC headless scenario mode: " + mode);
 }
 
-void femicActivateHeadlessMinimumTarget(String targetLabel, double minAnnual, boolean maxActive) {
+void femicConfigureHeadlessBaseHarvestTarget(String targetLabel, double minAnnual) {
    Target target = control.getTarget(targetLabel);
    if (target == null)
       throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
 
    target.setActive(true);
    target.setMinActive(true);
-   target.setMaxActive(maxActive);
+   target.setMaxActive(true);
+   target.setLinear(true);
 
-   for (int i = 1; i < Horizon.periods; i++)
+   target.setMaximum(200000f, 0);
+   for (int i = 1; i < Horizon.periods; i++) {
       target.setMinimum((float)(minAnnual * Horizon.intervals[i]), i);
+      target.setMaximum(200000f, i);
+   }
 }
 
 void femicConfigureHeadlessEvenFlowTarget(String targetLabel) {
@@ -201,11 +205,12 @@ void femicRunHeadlessStage() {
          if (femicHeadlessScenarioMinAnnual != null)
             minAnnual = femicHeadlessScenarioMinAnnual.doubleValue();
 
-         femicActivateHeadlessMinimumTarget(baseTargetLabel, minAnnual, false);
+         femicConfigureHeadlessBaseHarvestTarget(baseTargetLabel, minAnnual);
          femicHeadlessTrace("seeded underlying harvest target="
                             + baseTargetLabel
                             + " minAnnual="
-                            + minAnnual);
+                            + minAnnual
+                            + " linear=true max=200000");
 
          int seedIterations = femicHeadlessIterations;
          int flowIterations = 0;

--- a/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
+++ b/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
@@ -1,0 +1,161 @@
+/*
+ * Shared helpers for FEMIC-triggered no-GUI Patchworks runs.
+ *
+ * Contract:
+ *   args[0] = fully qualified PIN path (Patchworks standard)
+ *   args[1] = "__femic_headless__" sentinel
+ *   args[2] = reportWriter.saveStage(...) label/path
+ *   args[3] = iteration count
+ *   args[4] = objective improvement threshold
+ */
+
+boolean femicHeadlessMode = false;
+String femicHeadlessStageLabel = "headless_runs/femic";
+int femicHeadlessIterations = 1;
+double femicHeadlessImprovement = 0.0d;
+String femicHeadlessTraceLogPath = null;
+
+String femicThrowableToString(Throwable ex) {
+   java.io.StringWriter sw = new java.io.StringWriter();
+   java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+   ex.printStackTrace(pw);
+   pw.flush();
+   return sw.toString();
+}
+
+void femicHeadlessTrace(String message) {
+   String line = "[FEMIC headless] " + message;
+   print(line);
+   if (femicHeadlessTraceLogPath == null || femicHeadlessTraceLogPath.trim().length() == 0)
+      return;
+
+   java.io.PrintWriter writer = null;
+   try {
+      java.io.File traceFile = new java.io.File(femicHeadlessTraceLogPath);
+      java.io.File parent = traceFile.getParentFile();
+      if (parent != null)
+         parent.mkdirs();
+      writer = new java.io.PrintWriter(new java.io.FileWriter(traceFile, true));
+      writer.println(line);
+      writer.flush();
+   } catch (Throwable ex) {
+      print("[FEMIC headless] trace write failed: " + ex);
+   } finally {
+      if (writer != null)
+         writer.close();
+   }
+}
+
+boolean femicConfigureHeadlessFromArgs() {
+   if (args == void || args.length < 2)
+      return false;
+
+   if (!"__femic_headless__".equals(args[1]))
+      return false;
+
+   femicHeadlessMode = true;
+
+   if (args.length >= 3 && args[2] != null && args[2].trim().length() > 0)
+      femicHeadlessStageLabel = args[2].trim();
+
+   if (args.length >= 4 && args[3] != null && args[3].trim().length() > 0)
+      femicHeadlessIterations = Integer.parseInt(args[3].trim());
+
+   if (args.length >= 5 && args[4] != null && args[4].trim().length() > 0)
+      femicHeadlessImprovement = Double.parseDouble(args[4].trim());
+
+   if (args.length >= 6 && args[5] != null && args[5].trim().length() > 0)
+      femicHeadlessTraceLogPath = args[5].trim();
+
+   femicHeadlessTrace("mode enabled: stage="
+                      + femicHeadlessStageLabel
+                      + " iterations="
+                      + femicHeadlessIterations
+                      + " improvement="
+                      + femicHeadlessImprovement
+                      + " trace="
+                      + femicHeadlessTraceLogPath);
+   return true;
+}
+
+void femicRunHeadlessStage() {
+   boolean startedScheduler = false;
+   try {
+      femicHeadlessTrace("run stage entered; isSuspended=" + control.isSuspended());
+      if (femicHeadlessIterations > 0) {
+         if (control.isSuspended()) {
+            femicHeadlessTrace("scheduler suspended; issuing resume");
+            try {
+               control.resume();
+               startedScheduler = true;
+               femicHeadlessTrace("resume completed");
+            } catch (IllegalStateException ex) {
+               if (String.valueOf(ex).indexOf("Not suspended") < 0)
+                  throw ex;
+               femicHeadlessTrace("resume raced with active scheduler; continuing");
+            }
+         } else {
+            femicHeadlessTrace("scheduler already active; skip explicit resume");
+         }
+
+         if (femicHeadlessImprovement > 0.0d)
+            femicHeadlessTrace("waiting for progress: attempts="
+                               + femicHeadlessIterations
+                               + " improvement="
+                               + femicHeadlessImprovement);
+         else
+            femicHeadlessTrace("waiting for iterations: attempts="
+                               + femicHeadlessIterations);
+
+         if (femicHeadlessImprovement > 0.0d)
+            control.waitForProgress(femicHeadlessIterations, femicHeadlessImprovement);
+         else
+            control.waitForIterations(femicHeadlessIterations);
+
+         femicHeadlessTrace("wait completed; isSuspended=" + control.isSuspended());
+      } else {
+         femicHeadlessTrace("iterations <= 0; skipping scheduler wait");
+      }
+   } finally {
+      if (!control.isSuspended()) {
+         femicHeadlessTrace("issuing suspend after wait");
+         control.suspend();
+      } else if (startedScheduler) {
+         femicHeadlessTrace("scheduler already suspended before cleanup");
+      } else {
+         femicHeadlessTrace("leaving scheduler state unchanged (already suspended)");
+      }
+   }
+
+   femicHeadlessTrace("saving stage " + femicHeadlessStageLabel);
+   reportWriter.saveStage(femicHeadlessStageLabel);
+   femicHeadlessTrace("saveStage completed");
+}
+
+void femicQueueHeadlessStage() {
+   if (!femicHeadlessMode)
+      return;
+
+   Runnable worker = new Runnable() {
+      public void run() {
+         try {
+            femicHeadlessTrace("worker thread started");
+            femicHeadlessTrace("waiting until initialized");
+            control.waitUntilInitialized();
+            femicHeadlessTrace("waitUntilInitialized completed");
+            femicRunHeadlessStage();
+         } catch (InterruptedException ex) {
+            femicHeadlessTrace("stage interrupted: " + ex);
+         } catch (Throwable ex) {
+            femicHeadlessTrace("stage failed: " + ex);
+            femicHeadlessTrace(femicThrowableToString(ex));
+            ex.printStackTrace();
+         }
+      }
+   };
+
+   Thread headlessThread = new Thread(worker, "femic-headless-stage");
+   headlessThread.setDaemon(false);
+    femicHeadlessTrace("starting worker thread");
+   headlessThread.start();
+}

--- a/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
+++ b/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
@@ -7,6 +7,10 @@
  *   args[2] = reportWriter.saveStage(...) label/path
  *   args[3] = iteration count
  *   args[4] = objective improvement threshold
+ *   args[5] = trace log path
+ *   args[6] = optional scenario mode
+ *   args[7] = optional scenario target label
+ *   args[8] = optional scenario minimum annual value
  */
 
 boolean femicHeadlessMode = false;
@@ -14,6 +18,9 @@ String femicHeadlessStageLabel = "headless_runs/femic";
 int femicHeadlessIterations = 1;
 double femicHeadlessImprovement = 0.0d;
 String femicHeadlessTraceLogPath = null;
+String femicHeadlessScenarioMode = "none";
+String femicHeadlessScenarioTargetLabel = null;
+Double femicHeadlessScenarioMinAnnual = null;
 
 String femicThrowableToString(Throwable ex) {
    java.io.StringWriter sw = new java.io.StringWriter();
@@ -67,39 +74,169 @@ boolean femicConfigureHeadlessFromArgs() {
    if (args.length >= 6 && args[5] != null && args[5].trim().length() > 0)
       femicHeadlessTraceLogPath = args[5].trim();
 
+   if (args.length >= 7 && args[6] != null && args[6].trim().length() > 0)
+      femicHeadlessScenarioMode = args[6].trim();
+
+   if (args.length >= 8 && args[7] != null && args[7].trim().length() > 0)
+      femicHeadlessScenarioTargetLabel = args[7].trim();
+
+   if (args.length >= 9 && args[8] != null && args[8].trim().length() > 0)
+      femicHeadlessScenarioMinAnnual = new Double(Double.parseDouble(args[8].trim()));
+
    femicHeadlessTrace("mode enabled: stage="
                       + femicHeadlessStageLabel
                       + " iterations="
                       + femicHeadlessIterations
                       + " improvement="
                       + femicHeadlessImprovement
+                      + " scenario_mode="
+                      + femicHeadlessScenarioMode
+                      + " scenario_target="
+                      + femicHeadlessScenarioTargetLabel
+                      + " scenario_min_annual="
+                      + femicHeadlessScenarioMinAnnual
                       + " trace="
                       + femicHeadlessTraceLogPath);
    return true;
 }
 
+void femicConfigureHeadlessScenario() {
+   String mode = femicHeadlessScenarioMode == null ? "none" : femicHeadlessScenarioMode.trim();
+   if (mode.length() == 0 || "none".equalsIgnoreCase(mode)) {
+      femicHeadlessTrace("no headless scenario mode requested");
+      return;
+   }
+
+   if ("max-even-flow-smoke".equalsIgnoreCase(mode)) {
+      String targetLabel = femicHeadlessScenarioTargetLabel;
+      if (targetLabel == null || targetLabel.trim().length() == 0)
+         targetLabel = "product.Yield.managed.Total";
+
+      double minAnnual = 1000.0d;
+      if (femicHeadlessScenarioMinAnnual != null)
+         minAnnual = femicHeadlessScenarioMinAnnual.doubleValue();
+
+      Target target = control.getTarget(targetLabel);
+      if (target == null)
+         throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+      femicHeadlessTrace("validated max-even-flow smoke target="
+                         + targetLabel
+                         + " minAnnual="
+                         + minAnnual);
+      return;
+   }
+
+      throw new IllegalStateException("Unsupported FEMIC headless scenario mode: " + mode);
+}
+
+void femicActivateHeadlessMinimumTarget(String targetLabel, double minAnnual, boolean maxActive) {
+   Target target = control.getTarget(targetLabel);
+   if (target == null)
+      throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+   target.setActive(true);
+   target.setMinActive(true);
+   target.setMaxActive(maxActive);
+
+   for (int i = 1; i < Horizon.periods; i++)
+      target.setMinimum((float)(minAnnual * Horizon.intervals[i]), i);
+}
+
+void femicConfigureHeadlessEvenFlowTarget(String targetLabel) {
+   Target target = control.getTarget(targetLabel);
+   if (target == null)
+      throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+   target.setActive(true);
+   target.setMinActive(true);
+   target.setMaxActive(true);
+
+   for (int i = 0; i < Horizon.periods; i++) {
+      target.setMinimum(0f, i);
+      target.setMaximum(0f, i);
+      target.setMinWeight(100f, i);
+      target.setMaxWeight(100f, i);
+   }
+}
+
+void femicWaitHeadlessIterations(int waitCount) {
+   if (waitCount <= 0) {
+      femicHeadlessTrace("wait count <= 0; skipping scheduler wait");
+      return;
+   }
+
+   if (femicHeadlessImprovement > 0.0d)
+      femicHeadlessTrace("waiting for progress: attempts="
+                         + waitCount
+                         + " improvement="
+                         + femicHeadlessImprovement);
+   else
+      femicHeadlessTrace("waiting for iterations: attempts=" + waitCount);
+
+   if (femicHeadlessImprovement > 0.0d)
+      control.waitForProgress(waitCount, femicHeadlessImprovement);
+   else
+      control.waitForIterations(waitCount);
+
+   femicHeadlessTrace("wait completed; isSuspended=" + control.isSuspended());
+}
+
 void femicRunHeadlessStage() {
    try {
       femicHeadlessTrace("run stage entered; isSuspended=" + control.isSuspended());
-      if (femicHeadlessIterations > 0) {
+      femicConfigureHeadlessScenario();
+
+      if ("max-even-flow-smoke".equalsIgnoreCase(femicHeadlessScenarioMode)) {
+         String requestedTargetLabel = femicHeadlessScenarioTargetLabel;
+         if (requestedTargetLabel == null || requestedTargetLabel.trim().length() == 0)
+            requestedTargetLabel = "product.Yield.managed.Total";
+
+         String baseTargetLabel = requestedTargetLabel;
+         if (requestedTargetLabel.startsWith("flow.even."))
+            baseTargetLabel = requestedTargetLabel.substring("flow.even.".length());
+
+         String flowTargetLabel = "flow.even." + baseTargetLabel;
+         double minAnnual = 1000.0d;
+         if (femicHeadlessScenarioMinAnnual != null)
+            minAnnual = femicHeadlessScenarioMinAnnual.doubleValue();
+
+         femicActivateHeadlessMinimumTarget(baseTargetLabel, minAnnual, false);
+         femicHeadlessTrace("seeded underlying harvest target="
+                            + baseTargetLabel
+                            + " minAnnual="
+                            + minAnnual);
+
+         int seedIterations = femicHeadlessIterations;
+         int flowIterations = 0;
+         if (control.getTarget(flowTargetLabel) != null && femicHeadlessIterations > 1) {
+            seedIterations = Math.max(1, femicHeadlessIterations / 2);
+            flowIterations = femicHeadlessIterations - seedIterations;
+         }
+
          femicHeadlessTrace("delegating scheduler start to waitFor*; initial isSuspended="
                             + control.isSuspended());
+         femicWaitHeadlessIterations(seedIterations);
 
-         if (femicHeadlessImprovement > 0.0d)
-            femicHeadlessTrace("waiting for progress: attempts="
-                               + femicHeadlessIterations
-                               + " improvement="
-                               + femicHeadlessImprovement);
-         else
-            femicHeadlessTrace("waiting for iterations: attempts="
-                               + femicHeadlessIterations);
+         if (flowIterations > 0) {
+            if (!control.isSuspended()) {
+               femicHeadlessTrace("issuing suspend between seed and flow phases");
+               control.suspend();
+            }
 
-         if (femicHeadlessImprovement > 0.0d)
-            control.waitForProgress(femicHeadlessIterations, femicHeadlessImprovement);
-         else
-            control.waitForIterations(femicHeadlessIterations);
-
-         femicHeadlessTrace("wait completed; isSuspended=" + control.isSuspended());
+            femicConfigureHeadlessEvenFlowTarget(flowTargetLabel);
+            femicHeadlessTrace("activated even-flow companion target="
+                               + flowTargetLabel
+                               + " target=0 weight=100"
+                               + " after seed phase");
+            femicHeadlessTrace("delegating scheduler restart to waitFor* after seed phase; initial isSuspended="
+                               + control.isSuspended());
+            femicWaitHeadlessIterations(flowIterations);
+         }
+      } else if (femicHeadlessIterations > 0) {
+         femicHeadlessTrace("delegating scheduler start to waitFor*; initial isSuspended="
+                            + control.isSuspended());
+         femicWaitHeadlessIterations(femicHeadlessIterations);
       } else {
          femicHeadlessTrace("iterations <= 0; skipping scheduler wait");
       }

--- a/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
+++ b/models/k3z_patchworks_model/analysis/headless_runtime_common.bsh
@@ -79,24 +79,11 @@ boolean femicConfigureHeadlessFromArgs() {
 }
 
 void femicRunHeadlessStage() {
-   boolean startedScheduler = false;
    try {
       femicHeadlessTrace("run stage entered; isSuspended=" + control.isSuspended());
       if (femicHeadlessIterations > 0) {
-         if (control.isSuspended()) {
-            femicHeadlessTrace("scheduler suspended; issuing resume");
-            try {
-               control.resume();
-               startedScheduler = true;
-               femicHeadlessTrace("resume completed");
-            } catch (IllegalStateException ex) {
-               if (String.valueOf(ex).indexOf("Not suspended") < 0)
-                  throw ex;
-               femicHeadlessTrace("resume raced with active scheduler; continuing");
-            }
-         } else {
-            femicHeadlessTrace("scheduler already active; skip explicit resume");
-         }
+         femicHeadlessTrace("delegating scheduler start to waitFor*; initial isSuspended="
+                            + control.isSuspended());
 
          if (femicHeadlessImprovement > 0.0d)
             femicHeadlessTrace("waiting for progress: attempts="
@@ -120,10 +107,8 @@ void femicRunHeadlessStage() {
       if (!control.isSuspended()) {
          femicHeadlessTrace("issuing suspend after wait");
          control.suspend();
-      } else if (startedScheduler) {
-         femicHeadlessTrace("scheduler already suspended before cleanup");
       } else {
-         femicHeadlessTrace("leaving scheduler state unchanged (already suspended)");
+         femicHeadlessTrace("scheduler already suspended before cleanup");
       }
    }
 

--- a/models/k3z_patchworks_model/analysis/intensive_variant_common.bsh
+++ b/models/k3z_patchworks_model/analysis/intensive_variant_common.bsh
@@ -12,6 +12,7 @@ boolean usePatches = false;
 sourceRelative("../scripts/targets/flowTargets.bsh");
 sourceRelative("../scripts/targets/qmdRatioAccounts.bsh");
 sourceRelative("../scripts/targets/seralStages.bsh");
+sourceRelative("headless_runtime_common.bsh");
 
 blocks = tracks_path_prefix + "blocks.csv";
 curves = tracks_path_prefix + "curves.csv";
@@ -53,95 +54,99 @@ int Patchworks_TargetInit() {
 }
 
 int PatchWorks_Init() {
-   classic_GUI(control);
+   femicConfigureHeadlessFromArgs();
 
-    DefaultTheme def = new DefaultTheme(
-        blockData,
-        new PolygonSymbol(new Color(204, 204, 255))
-    );
-    Layer defLayer = new GeoRelLayer(blockData, def);
-    layers.add(defLayer);
+   if (!femicHeadlessMode) {
+      classic_GUI(control);
 
-    UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
-    currTreatTheme.setFieldname("CURRENTTREATMENT");
-    currTreatTheme.addElement(
-        new ThemeElement("CC", new PolygonSymbol(new Color(200, 60, 60))),
-        "CC"
-    );
-    currTreatTheme.addElement(
-        new ThemeElement("PCT", new PolygonSymbol(new Color(120, 170, 235))),
-        "PCT"
-    );
-    currTreatTheme.addElement(
-        new ThemeElement("CT", new PolygonSymbol(new Color(80, 170, 110))),
-        "CT"
-    );
-    currTreatTheme.addElement(
-        new ThemeElement("F1", new PolygonSymbol(new Color(80, 140, 220))),
-        "F1"
-    );
-    currTreatTheme.addElement(
-        new ThemeElement("F2", new PolygonSymbol(new Color(170, 110, 210))),
-        "F2"
-    );
-    currTreatTheme.addElement(
-        new ThemeElement("F3", new PolygonSymbol(new Color(230, 160, 70))),
-        "F3"
-    );
-    currTreatTheme.setCaption("Current Treatments");
-    currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
-    blockData.addTheme(currTreatTheme);
-    GeoRelLayer currTreatLayer = new GeoRelLayer(blockData, currTreatTheme);
-    currTreatLayer.setVisible(false);
-    layers.add(currTreatLayer);
+      DefaultTheme def = new DefaultTheme(
+          blockData,
+          new PolygonSymbol(new Color(204, 204, 255))
+      );
+      Layer defLayer = new GeoRelLayer(blockData, def);
+      layers.add(defLayer);
 
-    UniqueValueTheme latestTreatTheme = new UniqueValueTheme(blockData);
-    latestTreatTheme.setFieldname("LASTTREATMENT");
-    latestTreatTheme.addElement(
-        new ThemeElement("CC", new PolygonSymbol(new Color(200, 60, 60))),
-        "CC"
-    );
-    latestTreatTheme.addElement(
-        new ThemeElement("PCT", new PolygonSymbol(new Color(120, 170, 235))),
-        "PCT"
-    );
-    latestTreatTheme.addElement(
-        new ThemeElement("CT", new PolygonSymbol(new Color(80, 170, 110))),
-        "CT"
-    );
-    latestTreatTheme.addElement(
-        new ThemeElement("F1", new PolygonSymbol(new Color(80, 140, 220))),
-        "F1"
-    );
-    latestTreatTheme.addElement(
-        new ThemeElement("F2", new PolygonSymbol(new Color(170, 110, 210))),
-        "F2"
-    );
-    latestTreatTheme.addElement(
-        new ThemeElement("F3", new PolygonSymbol(new Color(230, 160, 70))),
-        "F3"
-    );
-    latestTreatTheme.setCaption("Latest Treatments");
-    latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
-    blockData.addTheme(latestTreatTheme);
-    GeoRelLayer latestTreatLayer = new GeoRelLayer(blockData, latestTreatTheme);
-    latestTreatLayer.setVisible(false);
-    layers.add(latestTreatLayer);
+      UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
+      currTreatTheme.setFieldname("CURRENTTREATMENT");
+      currTreatTheme.addElement(
+          new ThemeElement("CC", new PolygonSymbol(new Color(200, 60, 60))),
+          "CC"
+      );
+      currTreatTheme.addElement(
+          new ThemeElement("PCT", new PolygonSymbol(new Color(120, 170, 235))),
+          "PCT"
+      );
+      currTreatTheme.addElement(
+          new ThemeElement("CT", new PolygonSymbol(new Color(80, 170, 110))),
+          "CT"
+      );
+      currTreatTheme.addElement(
+          new ThemeElement("F1", new PolygonSymbol(new Color(80, 140, 220))),
+          "F1"
+      );
+      currTreatTheme.addElement(
+          new ThemeElement("F2", new PolygonSymbol(new Color(170, 110, 210))),
+          "F2"
+      );
+      currTreatTheme.addElement(
+          new ThemeElement("F3", new PolygonSymbol(new Color(230, 160, 70))),
+          "F3"
+      );
+      currTreatTheme.setCaption("Current Treatments");
+      currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+      blockData.addTheme(currTreatTheme);
+      GeoRelLayer currTreatLayer = new GeoRelLayer(blockData, currTreatTheme);
+      currTreatLayer.setVisible(false);
+      layers.add(currTreatLayer);
 
-    AlphaComposite alpha = AlphaComposite.SrcOver;
-    global.seral2 = new DitherTheme(blockData, "feature.Seral.");
-    seral2.setCaption("Dithered Seral Stage");
-    seral2.setAlpha(alpha);
-    seral2.setIsScaled(false);
-    seral2.addElement("Regen", new Color(250, 230, 0), "feature.Seral.regenerating");
-    seral2.addElement("Young", new Color(200, 250, 200), "feature.Seral.young");
-    seral2.addElement("Immature", new Color(160, 220, 160), "feature.Seral.immature");
-    seral2.addElement("Mature", new Color(100, 190, 100), "feature.Seral.mature");
-    seral2.addElement("Old", new Color(128, 64, 64), "feature.Seral.overmature");
-    blockData.addTheme(seral2, "Dithered Seral Stage");
-    Layer seral2Layer = new GeoRelLayer(blockData, seral2);
-    seral2Layer.setTitle("Seral Stages");
-    layers.add(seral2Layer);
+      UniqueValueTheme latestTreatTheme = new UniqueValueTheme(blockData);
+      latestTreatTheme.setFieldname("LASTTREATMENT");
+      latestTreatTheme.addElement(
+          new ThemeElement("CC", new PolygonSymbol(new Color(200, 60, 60))),
+          "CC"
+      );
+      latestTreatTheme.addElement(
+          new ThemeElement("PCT", new PolygonSymbol(new Color(120, 170, 235))),
+          "PCT"
+      );
+      latestTreatTheme.addElement(
+          new ThemeElement("CT", new PolygonSymbol(new Color(80, 170, 110))),
+          "CT"
+      );
+      latestTreatTheme.addElement(
+          new ThemeElement("F1", new PolygonSymbol(new Color(80, 140, 220))),
+          "F1"
+      );
+      latestTreatTheme.addElement(
+          new ThemeElement("F2", new PolygonSymbol(new Color(170, 110, 210))),
+          "F2"
+      );
+      latestTreatTheme.addElement(
+          new ThemeElement("F3", new PolygonSymbol(new Color(230, 160, 70))),
+          "F3"
+      );
+      latestTreatTheme.setCaption("Latest Treatments");
+      latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+      blockData.addTheme(latestTreatTheme);
+      GeoRelLayer latestTreatLayer = new GeoRelLayer(blockData, latestTreatTheme);
+      latestTreatLayer.setVisible(false);
+      layers.add(latestTreatLayer);
+
+      AlphaComposite alpha = AlphaComposite.SrcOver;
+      global.seral2 = new DitherTheme(blockData, "feature.Seral.");
+      seral2.setCaption("Dithered Seral Stage");
+      seral2.setAlpha(alpha);
+      seral2.setIsScaled(false);
+      seral2.addElement("Regen", new Color(250, 230, 0), "feature.Seral.regenerating");
+      seral2.addElement("Young", new Color(200, 250, 200), "feature.Seral.young");
+      seral2.addElement("Immature", new Color(160, 220, 160), "feature.Seral.immature");
+      seral2.addElement("Mature", new Color(100, 190, 100), "feature.Seral.mature");
+      seral2.addElement("Old", new Color(128, 64, 64), "feature.Seral.overmature");
+      blockData.addTheme(seral2, "Dithered Seral Stage");
+      Layer seral2Layer = new GeoRelLayer(blockData, seral2);
+      seral2Layer.setTitle("Seral Stages");
+      layers.add(seral2Layer);
+   }
 
     RangeLabel[] ageClass = new RangeLabel[] {
       new RangeLabel("Regen", -5, 0),
@@ -168,6 +173,9 @@ int PatchWorks_Init() {
          null,
          false
     ));
+
+    if (femicHeadlessMode)
+       femicQueueHeadlessStage();
 
     return 1;
 }


### PR DESCRIPTION
## Summary
- encode the minimal useful headless Patchworks scheduler recipe in the K3Z BeanShell helper
- use nalysis/base.pin as the Phase 49 proving-ground surface
- capture the stronger base closeout proof from the real no-GUI run lifecycle

## Validation
- real headless proving-ground run p49_base_closeout_20260328b
- saved stage with active base + even-flow targets
- non-empty schedule.csv and target report outputs
