### PR TITLE
P92K: Own K3Z Patchworks variant registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
   "pandas",
+  "PyYAML>=6",
 ]
 
 [project.optional-dependencies]
@@ -22,8 +23,14 @@ dev = [
 [project.entry-points."femic.fmg_bundle_auxiliary"]
 k3z = "k3z_femic.fmg:provider_factory"
 
+[project.entry-points."femic.patchworks_variant_registries"]
+k3z = "k3z_femic.patchworks_variants:provider_factory"
+
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+k3z_femic = ["resources/*.yaml"]
 
 [tool.ruff]
 line-length = 100

--- a/src/k3z_femic/patchworks_variants.py
+++ b/src/k3z_femic/patchworks_variants.py
@@ -1,0 +1,31 @@
+"""K3Z-owned Patchworks variant registry provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class K3zPatchworksVariantRegistryProvider:
+    """Expose K3Z Patchworks variants to FEMIC through entry-point discovery."""
+
+    provider_id: str = "k3z"
+    registry_base_dir: Path = field(default_factory=lambda: Path(__file__).resolve().parents[2])
+
+    def load_registry_payload(self) -> dict[str, Any]:
+        resource = resources.files("k3z_femic.resources").joinpath("patchworks_variants.yaml")
+        payload = yaml.safe_load(resource.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("K3Z Patchworks variant registry payload must be a mapping.")
+        return payload
+
+
+def provider_factory() -> K3zPatchworksVariantRegistryProvider:
+    """Return the K3Z Patchworks variant registry provider."""
+
+    return K3zPatchworksVariantRegistryProvider()

--- a/src/k3z_femic/resources/__init__.py
+++ b/src/k3z_femic/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged K3Z registry resources."""

--- a/src/k3z_femic/resources/patchworks_variants.yaml
+++ b/src/k3z_femic/resources/patchworks_variants.yaml
@@ -1,0 +1,156 @@
+instances:
+- instance_id: k3z
+  label: K3Z example instance
+  default_scenario_set_id: k3z.proving_ground
+variants:
+- variant_id: k3z.base
+  label: K3Z base
+  instance_id: k3z
+  variant_family: baseline
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/base.pin
+  runtime_config: config/patchworks.runtime.windows.yaml
+  default: true
+  default_scenario_id: even_flow_smoke
+  notes:
+  - Canonical baseline K3Z Patchworks launch surface.
+  scenarios:
+  - scenario_id: even_flow_smoke
+    label: K3Z base even-flow smoke
+    mode: max-even-flow-smoke
+    target: product.Yield.managed.Total
+    iterations: 100000
+    improvement: 0.0
+- variant_id: k3z.ctfert_l15h5
+  label: K3Z CT/fert L15/M10/H5
+  instance_id: k3z
+  variant_family: ctfert
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/ctfert_l15h5.pin
+  runtime_config: config/patchworks.runtime.ctfert_l15h5.windows.yaml
+- variant_id: k3z.ctfert_l20h0
+  label: K3Z CT/fert L20/M10/H0
+  instance_id: k3z
+  variant_family: ctfert
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/ctfert_l20h0.pin
+  runtime_config: config/patchworks.runtime.ctfert_l20h0.windows.yaml
+- variant_id: k3z.intensive_light
+  label: K3Z intensive light
+  instance_id: k3z
+  variant_family: intensive
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/intensive_light.pin
+  runtime_config: config/patchworks.runtime.intensive_light.windows.yaml
+- variant_id: k3z.intensive_moderate
+  label: K3Z intensive moderate
+  instance_id: k3z
+  variant_family: intensive
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/intensive_moderate.pin
+  runtime_config: config/patchworks.runtime.intensive_moderate.windows.yaml
+- variant_id: k3z.intensive_heavy
+  label: K3Z intensive heavy
+  instance_id: k3z
+  variant_family: intensive
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/intensive_heavy.pin
+  runtime_config: config/patchworks.runtime.intensive_heavy.windows.yaml
+- variant_id: k3z.intensive_light_standstructure
+  label: K3Z intensive light stand-structure proving ground
+  instance_id: k3z
+  variant_family: proving_ground
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/intensive_light_standstructure.pin
+  runtime_config: config/patchworks.runtime.intensive_light_standstructure.windows.yaml
+  default_scenario_id: even_flow_smoke
+  scenarios:
+  - scenario_id: even_flow_smoke
+    label: K3Z proving-ground even-flow smoke
+    mode: max-even-flow-smoke
+    target: product.Yield.managed.Total
+    iterations: 100000
+    improvement: 0.0
+- variant_id: k3z.pct_light
+  label: K3Z PCT light
+  instance_id: k3z
+  variant_family: pct
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/pct_light.pin
+  runtime_config: config/patchworks.runtime.pct_light.windows.yaml
+- variant_id: k3z.pct_moderate
+  label: K3Z PCT moderate
+  instance_id: k3z
+  variant_family: pct
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/pct_moderate.pin
+  runtime_config: config/patchworks.runtime.pct_moderate.windows.yaml
+- variant_id: k3z.pct_heavy
+  label: K3Z PCT heavy
+  instance_id: k3z
+  variant_family: pct
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/pct_heavy.pin
+  runtime_config: config/patchworks.runtime.pct_heavy.windows.yaml
+- variant_id: k3z.pct_heavy_zones
+  label: K3Z PCT heavy zones
+  instance_id: k3z
+  variant_family: pct
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/pct_heavy_zones.pin
+  runtime_config: config/patchworks.runtime.pct_heavy_zones.windows.yaml
+- variant_id: k3z.overlay_basecase_riparian
+  label: K3Z overlay basecase riparian
+  instance_id: k3z
+  variant_family: overlay
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/overlay_basecase_riparian.pin
+  runtime_config: config/patchworks.runtime.overlay.basecase_riparian.windows.yaml
+- variant_id: k3z.overlay_basecase_sum
+  label: K3Z overlay basecase sum
+  instance_id: k3z
+  variant_family: overlay
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/overlay_basecase_sum.pin
+  runtime_config: config/patchworks.runtime.overlay.basecase_sum.windows.yaml
+- variant_id: k3z.overlay_scenario1_sum
+  label: K3Z overlay scenario1 sum
+  instance_id: k3z
+  variant_family: overlay
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/overlay_scenario1_sum.pin
+  runtime_config: config/patchworks.runtime.overlay.scenario1_sum.windows.yaml
+- variant_id: k3z.overlay_scenario2_sum
+  label: K3Z overlay scenario2 sum
+  instance_id: k3z
+  variant_family: overlay
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/k3z_patchworks_model/analysis/overlay_scenario2_sum.pin
+  runtime_config: config/patchworks.runtime.overlay.scenario2_sum.windows.yaml
+scenario_sets:
+- scenario_set_id: k3z.proving_ground
+  label: K3Z proving-ground scenario smoke set
+  instance_id: k3z
+  scenario_set_family: proving_ground
+  default: true
+  notes:
+  - Sequential proving-ground smoke set for the shipped K3Z registry surface.
+  mode: sequential
+  scenarios:
+  - k3z.base/even_flow_smoke
+  - k3z.intensive_light_standstructure/even_flow_smoke

--- a/tests/test_patchworks_variants.py
+++ b/tests/test_patchworks_variants.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+from k3z_femic.patchworks_variants import provider_factory
+
+
+def test_patchworks_variant_provider_metadata() -> None:
+    provider = provider_factory()
+
+    assert provider.provider_id == "k3z"
+    assert provider.registry_base_dir == Path(__file__).resolve().parents[1]
+
+    payload = provider.load_registry_payload()
+    assert payload["instances"][0]["instance_id"] == "k3z"
+    variant_ids = {item["variant_id"] for item in payload["variants"]}
+    assert "k3z.base" in variant_ids
+    assert "k3z.intensive_light_standstructure" in variant_ids
+    base = next(item for item in payload["variants"] if item["variant_id"] == "k3z.base")
+    assert base["instance_root"] == "."
+    assert base["analysis_pin"] == "models/k3z_patchworks_model/analysis/base.pin"
+    assert base["runtime_config"] == "config/patchworks.runtime.windows.yaml"
+    assert payload["scenario_sets"][0]["scenario_set_id"] == "k3z.proving_ground"
+
+
+def test_package_exposes_patchworks_variant_registry_entry_point() -> None:
+    entry_points = metadata.entry_points().select(group="femic.patchworks_variant_registries")
+    matches = [entry_point for entry_point in entry_points if entry_point.name == "k3z"]
+    assert matches
+    assert matches[0].value == "k3z_femic.patchworks_variants:provider_factory"


### PR DESCRIPTION
## Summary

- expose the K3Z Patchworks variant registry through `femic.patchworks_variant_registries`
- move K3Z variant and scenario-set definitions into package data under `k3z_femic`
- add provider metadata and entry-point tests

Parent FEMIC issue: UBC-FRESH/femic#252
K3Z issue: #31

## Validation

- `python -m pip install -e .[dev]`
- `ruff check src tests`
- `pytest tests/test_patchworks_variants.py`
