### PR TITLE
P93K: Own K3Z instance catalog entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ k3z = "k3z_femic.fmg:provider_factory"
 [project.entry-points."femic.patchworks_variant_registries"]
 k3z = "k3z_femic.patchworks_variants:provider_factory"
 
+[project.entry-points."femic.instance_catalogs"]
+k3z = "k3z_femic.instance_catalog:provider_factory"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/k3z_femic/instance_catalog.py
+++ b/src/k3z_femic/instance_catalog.py
@@ -1,0 +1,29 @@
+"""K3Z-owned FEMIC instance catalog provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class K3zInstanceCatalogProvider:
+    """Expose the K3Z installable instance catalog entry to FEMIC."""
+
+    provider_id: str = "k3z"
+
+    def load_catalog_payload(self) -> dict[str, Any]:
+        resource = resources.files("k3z_femic.resources").joinpath("instance_catalog.yaml")
+        payload = yaml.safe_load(resource.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("K3Z instance catalog payload must be a mapping.")
+        return payload
+
+
+def provider_factory() -> K3zInstanceCatalogProvider:
+    """Return the K3Z instance catalog provider."""
+
+    return K3zInstanceCatalogProvider()

--- a/src/k3z_femic/resources/instance_catalog.yaml
+++ b/src/k3z_femic/resources/instance_catalog.yaml
@@ -1,0 +1,16 @@
+support_repos:
+- repo_id: femic-public-data
+  label: FEMIC public data mirror
+  repo_url: https://github.com/UBC-FRESH/femic-public-data.git
+  target_dirname: femic-public-data
+  notes:
+  - Annex-backed public data mirror used by shipped example instances.
+instances:
+- builtin_id: k3z
+  label: K3Z example instance
+  repo_url: https://github.com/UBC-FRESH/femic-k3z-instance.git
+  target_dirname: femic-k3z-instance
+  support_repo_ids:
+  - femic-public-data
+  notes:
+  - Canonical teaching example instance bundled in source checkouts.

--- a/tests/test_instance_catalog.py
+++ b/tests/test_instance_catalog.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from importlib import metadata
+
+from k3z_femic.instance_catalog import provider_factory
+
+
+def test_instance_catalog_provider_metadata() -> None:
+    provider = provider_factory()
+
+    assert provider.provider_id == "k3z"
+    payload = provider.load_catalog_payload()
+    assert payload["support_repos"][0]["repo_id"] == "femic-public-data"
+    assert payload["instances"][0]["builtin_id"] == "k3z"
+    assert payload["instances"][0]["target_dirname"] == "femic-k3z-instance"
+
+
+def test_package_exposes_instance_catalog_entry_point() -> None:
+    entry_points = metadata.entry_points().select(group="femic.instance_catalogs")
+    matches = [entry_point for entry_point in entry_points if entry_point.name == "k3z"]
+    assert matches
+    assert matches[0].value == "k3z_femic.instance_catalog:provider_factory"


### PR DESCRIPTION
## Summary
- Adds a K3Z-owned FEMIC instance catalog provider under `k3z_femic`.
- Registers the provider through the `femic.instance_catalogs` entry-point group.
- Moves K3Z installable instance metadata out of FEMIC core ownership.

## Validation
- `python -m pip install -e .[dev]`
- `ruff check src tests`
- `pytest tests/test_instance_catalog.py`

Closes #33.