### PR TITLE
Add FreshForge materialization overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyo
 *.tmp
 *.log
+runtime/freshforge/
 *.egg-info/
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,23 @@ It is intended to show how a complete FEMIC instance is structured and versioned
 
 ## Quickstart
 
-1. Install FEMIC and the K3Z-owned FEMIC extension package from source checkouts:
+1. From the parent FEMIC checkout, use FreshForge to verify and materialize the
+   K3Z teaching snapshot:
+
+```bash
+freshforge providers
+freshforge validate external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+freshforge inspect external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+freshforge plan external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+freshforge run external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --workdir runtime/freshforge --namespace k3z/materialization --json
+```
+
+K3Z currently uses plain-git materialization. The workflow verifies tracked
+paths and installs the editable K3Z package, but it does not enable
+`arbutus-s3` or run `datalad get`.
+
+2. Install FEMIC and the K3Z-owned FEMIC extension package from source checkouts
+   when working outside the parent FreshForge materialization path:
 
 ```bash
 python -m pip install /path/to/femic
@@ -42,19 +58,19 @@ defaults, including K3Z FMG auxiliary support loading, target-stratum count,
 plot limits, and VDYP curve-selection policy. FEMIC core provides the generic
 engines and extension seams.
 
-2. Validate case configuration and required paths:
+3. Validate case configuration and required paths:
 
 ```bash
 femic prep validate-case --run-config config/run_profile.k3z.yaml --tipsy-config-dir config/tipsy
 ```
 
-3. Run K3Z compile flow:
+4. Run K3Z compile flow:
 
 ```bash
 femic run --run-config config/run_profile.k3z.yaml
 ```
 
-4. Run the full reproducible K3Z rebuild sequence:
+5. Run the full reproducible K3Z rebuild sequence:
 
 ```bash
 femic instance rebuild \
@@ -64,7 +80,7 @@ femic instance rebuild \
   --run-id k3z_rebuild
 ```
 
-5. Rebuild-spec source of truth:
+6. Rebuild-spec source of truth:
 
 ```text
 config/rebuild.spec.yaml

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -4,7 +4,7 @@ Operator Runbook
 Fresh Setup
 -----------
 
-1. Initialize submodules and environment.
+1. From the parent FEMIC checkout, run the FreshForge materialization workflow.
 2. Validate prerequisites with case preflight.
 3. Confirm Patchworks runtime config resolves correctly.
 4. On Windows, confirm native runtime prerequisites are present:
@@ -19,7 +19,22 @@ Fresh Setup
 
 .. code-block:: bash
 
-   git submodule update --init --recursive
+   freshforge providers
+   freshforge validate external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+   freshforge inspect external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+   freshforge plan external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml
+   freshforge run external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --workdir runtime/freshforge --namespace k3z/materialization --json
+
+K3Z is currently a plain-git teaching snapshot. The FreshForge materialization
+workflow initializes the parent submodule, validates the parent Python
+environment, installs FEMIC/FreshForge and the editable K3Z package, verifies
+tracked K3Z paths, and writes a materialization report. It does not enable
+``arbutus-s3`` or run ``datalad get`` for K3Z.
+
+After materialization:
+
+.. code-block:: bash
+
    femic prep validate-case --run-config config/run_profile.k3z.yaml --tipsy-config-dir config/tipsy
    femic patchworks preflight --config config/patchworks.runtime.windows.yaml
 

--- a/planning/freshforge_materialization_overlay.md
+++ b/planning/freshforge_materialization_overlay.md
@@ -1,0 +1,17 @@
+# FreshForge K3Z Materialization Overlay
+
+K3Z is the third acceptance case for the reusable FEMIC FreshForge
+materialization provider. Unlike TFL6 and MKRF, the current K3Z teaching
+snapshot is plain git rather than a DataLad/git-annex dataset.
+
+The K3Z overlay therefore sets `annex.enabled: false`. The shared
+`femic.materialization` provider still initializes the parent submodule,
+validates the parent `.venv`, installs FEMIC with `dev` and `freshforge`
+extras, installs this K3Z package editable, verifies required tracked paths,
+and writes a materialization report. Annex initialization, special-remote
+enablement, and annex availability audit nodes become deterministic no-op
+success nodes that report annex is disabled by overlay configuration.
+
+The workflow targets the parent FEMIC checkout with K3Z at
+`external/femic-k3z-instance`. Standalone K3Z clone materialization and any
+future DataLad/LFS migration are separate decisions outside this phase.

--- a/workflows/freshforge/k3z_materialization_overlay.yaml
+++ b/workflows/freshforge/k3z_materialization_overlay.yaml
@@ -1,0 +1,31 @@
+instance:
+  root: external/femic-k3z-instance
+  submodule_path: external/femic-k3z-instance
+environment:
+  venv_path: .venv
+install:
+  extras:
+    - dev
+    - freshforge
+  requirements: []
+  editable_paths:
+    - external/femic-k3z-instance
+  packages: []
+annex:
+  enabled: false
+materialization:
+  required_paths:
+    - models
+    - config
+    - data
+    - docs
+    - workflows
+audit:
+  required_paths:
+    - models
+    - config
+    - data
+    - docs
+    - workflows
+report:
+  path: runtime/freshforge/k3z_materialization_report.json

--- a/workflows/freshforge/k3z_materialization_workflow.yaml
+++ b/workflows/freshforge/k3z_materialization_workflow.yaml
@@ -1,0 +1,93 @@
+workflow:
+  id: k3z_materialization
+  name: K3Z FreshForge materialization workflow
+  description: Parent-checkout FreshForge graph for verifying the plain-git K3Z model instance with the generic FEMIC materialization provider.
+nodes:
+  - id: check_toolchain
+    provider: femic.materialization.check_toolchain
+    outputs:
+      toolchain: toolchain_ok
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: check_python_environment
+    provider: femic.materialization.check_python_environment
+    needs:
+      - check_toolchain
+    inputs:
+      toolchain: check_toolchain.toolchain
+    outputs:
+      python_environment: python_environment_ok
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: install_packages
+    provider: femic.materialization.install_packages
+    needs:
+      - check_python_environment
+    inputs:
+      python_environment: check_python_environment.python_environment
+    outputs:
+      packages: packages_installed
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: init_submodules
+    provider: femic.materialization.init_submodules
+    needs:
+      - install_packages
+    inputs:
+      packages: install_packages.packages
+    outputs:
+      submodules: submodules_initialized
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: init_annex
+    provider: femic.materialization.init_annex
+    needs:
+      - init_submodules
+    inputs:
+      submodules: init_submodules.submodules
+    outputs:
+      annex_repository: annex_disabled
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: enable_special_remote
+    provider: femic.materialization.enable_special_remote
+    needs:
+      - init_annex
+    inputs:
+      annex_repository: init_annex.annex_repository
+    outputs:
+      special_remote: annex_disabled
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: materialize_paths
+    provider: femic.materialization.materialize_paths
+    needs:
+      - enable_special_remote
+    inputs:
+      special_remote: enable_special_remote.special_remote
+    outputs:
+      materialized_paths: k3z_paths_present
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: audit_annex_availability
+    provider: femic.materialization.audit_annex_availability
+    needs:
+      - materialize_paths
+    inputs:
+      materialized_paths: materialize_paths.materialized_paths
+    outputs:
+      annex_audit: annex_disabled
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+  - id: write_materialization_report
+    provider: femic.materialization.write_materialization_report
+    needs:
+      - audit_annex_availability
+    inputs:
+      annex_audit: audit_annex_availability.annex_audit
+    outputs:
+      materialization_report: k3z_materialization_report
+    parameters:
+      overlay: external/femic-k3z-instance/workflows/freshforge/k3z_materialization_overlay.yaml
+    artifacts:
+      report: runtime/freshforge/k3z_materialization_report.json


### PR DESCRIPTION
﻿## Summary

Adds the first K3Z FreshForge materialization workflow overlay. K3Z is currently a plain-git teaching snapshot, so the workflow uses the shared FEMIC `femic.materialization` provider with `annex.enabled: false`.

## Changes

- Added `workflows/freshforge/k3z_materialization_overlay.yaml` and `k3z_materialization_workflow.yaml`.
- Added a planning note documenting the plain-git materialization boundary.
- Updated README and operator runbook commands for parent-checkout FreshForge materialization.
- Ignored local `runtime/freshforge/` run reports.

## Validation

From the parent FEMIC checkout with FreshForge `0.1.0a5` in `.venv`:

- `python -m pytest tests/test_freshforge_materialization.py`
- `python -m ruff check src/femic/freshforge_materialization.py tests/test_freshforge_materialization.py`
- `python -m mypy src/femic/freshforge_materialization.py`
- `.venv\Scripts\python.exe -m freshforge providers --json`
- `.venv\Scripts\python.exe -m freshforge validate external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge inspect external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `.venv\Scripts\python.exe -m freshforge plan external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --json`
- `python -m freshforge run external/femic-k3z-instance/workflows/freshforge/k3z_materialization_workflow.yaml --workdir runtime/freshforge --namespace k3z/materialization --json`
- `sphinx-build -b html docs docs\_build\html -W`

The run wrote only ignored parent `runtime/freshforge/` output and did not enable `arbutus-s3` or run `datalad get`.

Closes #35.
